### PR TITLE
Bump actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,18 +19,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Deploy PR Preview
-        uses: rossjrw/pr-preview-action@v1.6.2
+        uses: rossjrw/pr-preview-action@v1.8.0
 
   deploy-main:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           keep_files: true


### PR DESCRIPTION
We're using the following actions either directly or transiently which depend on Node 20:

* actions/checkout@v4
* actions/upload-artifact@v4
* actions/deploy-pages@v4

We're now seeing warnings on our builds because Node 24 will become the default in GitHub Actions in 2nd June 2026. Bumping these actions to use more recent versions which support Node 24 should resolve these warnings.

This is also a nice safe repo to test these upgrades because it's all open and will not affect any live services if it needs more investigation.